### PR TITLE
VIDA-2097 - Encode + symbols in filter strings

### DIFF
--- a/Filter.php
+++ b/Filter.php
@@ -37,6 +37,8 @@ class Filter implements FilterInterface
      */
     public function addFilter($field, $value, $operator = '=')
     {
+        //Encode any + signs in the value so we don't lose them in the urlencode/decode process
+        $value = str_replace('+', '%2B', $value);
         $this->m_filter[] = $this->filterItem($field, $value, $operator);
     }
     


### PR DESCRIPTION
Plus symbols get swapped out for spaces when you urldecode in the api. Encoding them to %2B stops this from happening.