### PR TITLE
Updates to jsonSerialize methods for compliance with php8.2

### DIFF
--- a/Filter.php
+++ b/Filter.php
@@ -68,7 +68,7 @@ class Filter implements FilterInterface
      * serialized, it will come through correctly.
      * @return array
      */
-    public function jsonSerialize() 
+    public function jsonSerialize(): mixed
     {
         return $this->m_filter;
     }

--- a/FilterGroup.php
+++ b/FilterGroup.php
@@ -32,7 +32,7 @@ class FilterGroup implements FilterInterface
      * serializable.
      * @return type
      */
-    public function jsonSerialize() 
+    public function jsonSerialize(): mixed 
     {
         return array(
             'comparison' => (string)$this->m_conjunction,


### PR DESCRIPTION
Further updates for PHP8.2 compliance where methods are redeclared in a class and must match the declaration in the inherited class or interface.