### PR TITLE
Undeclared properties in classes now declared

### DIFF
--- a/User.php
+++ b/User.php
@@ -15,6 +15,7 @@ namespace iRAP\VidaSDK;
 class User extends Controllers\AbstractApiController
 {
     
+    protected $m_auth;
     /**
      * Start here! The constructor takes the App's authentication credentials, which will be 
      * supplied to you by iRAP and the user's authentication details. An Authentication object

--- a/models/UserAuthentication.php
+++ b/models/UserAuthentication.php
@@ -19,7 +19,8 @@ class UserAuthentication extends AbstractAuthentication
     protected $m_user_auth_id;
     protected $m_user_api_key;
     protected $m_user_protected_key;
-    
+    protected $m_app_private_key;
+    protected $m_user_private_key;
     
     /**
      * Takes the API token and user token if available and sets up the authentication member variable


### PR DESCRIPTION
For PHP8.2, class properties must be declared before use.