### PR TITLE
External file download method added

### DIFF
--- a/controllers/AbstractApiController.php
+++ b/controllers/AbstractApiController.php
@@ -2249,7 +2249,7 @@ abstract class AbstractApiController implements ApiInterface
      * @param string $language Language code (defaults to en-gb)
      * @return Response (Includes a URL for the file's location)
      */
-    public function requestDownloadFile(
+    public function requestDownloadFileExternal(
         string $type,
         int $datasetId,
         string $filename,
@@ -2257,6 +2257,6 @@ abstract class AbstractApiController implements ApiInterface
     {
         $downloadsController = new DownloadsController($this->getAuth());
         
-        return $downloadsController->requestDownloadFile($type, $datasetId, $filename, $language);
+        return $downloadsController->requestDownloadFileExternal($type, $datasetId, $filename, $language);
     }
 }

--- a/controllers/AbstractApiController.php
+++ b/controllers/AbstractApiController.php
@@ -2238,4 +2238,24 @@ abstract class AbstractApiController implements ApiInterface
     {
         return $this->setManager($identifier, $userId, false);
     }
+
+    /**
+     * Request for a file download (This only adds a file to the downloads queue, the file will not be available at the returned
+     * URL immediately)
+     * @param string $type could be any one of (core_before, core_before_endgps, core_after, core_after_endgps, complete_before, 
+     * complete_after, fe_before, fe_after, countermeasures, countermeasures_partial, chainages, upload)
+     * @param int $datasetId
+     * @param string $filename Name of the file (not including extension)
+     * @param string $language Language code (defaults to en-gb)
+     * @return Response (Includes a URL for the file's location)
+     */
+    public function requestDownloadFile(
+        string $type,
+        int $datasetId,
+        string $filename,
+        string $language = 'en-gb') : Response
+{
+    $downloadsController = new DownloadsController($this->getAuth());
+    
+    return $downloadsController->requestDownloadFile($type, $datasetId, $filename, $language);
 }

--- a/controllers/AbstractApiController.php
+++ b/controllers/AbstractApiController.php
@@ -2254,8 +2254,9 @@ abstract class AbstractApiController implements ApiInterface
         int $datasetId,
         string $filename,
         string $language = 'en-gb') : Response
-{
-    $downloadsController = new DownloadsController($this->getAuth());
-    
-    return $downloadsController->requestDownloadFile($type, $datasetId, $filename, $language);
+    {
+        $downloadsController = new DownloadsController($this->getAuth());
+        
+        return $downloadsController->requestDownloadFile($type, $datasetId, $filename, $language);
+    }
 }

--- a/controllers/ApiInterface.php
+++ b/controllers/ApiInterface.php
@@ -251,5 +251,5 @@ interface ApiInterface
 
     public function deleteManager(string $identifier, int ...$userId);
 
-    public function requestDownloadFile(string $type, int $datasetId, string $filename, string $language = 'en-gb');
+    public function requestDownloadFileExternal(string $type, int $datasetId, string $filename, string $language = 'en-gb');
 }

--- a/controllers/ApiInterface.php
+++ b/controllers/ApiInterface.php
@@ -250,4 +250,6 @@ interface ApiInterface
     public function addManager(string $identifier, int ...$userId);
 
     public function deleteManager(string $identifier, int ...$userId);
+
+    public function requestDownloadFile(string $type, int $datasetId, string $filename, string $language = 'en-gb');
 }

--- a/controllers/DownloadsController.php
+++ b/controllers/DownloadsController.php
@@ -25,7 +25,7 @@ class DownloadsController extends AbstractResourceController
      * @param string $filename Language code (Defaults to en-gb)
      * @return \iRAP\VidaSDK\Models\Response
      */
-    public function requestDownloadFile(string $type, int $datasetId, string $filename, string $language): Response
+    public function requestDownloadFileExternal(string $type, int $datasetId, string $filename, string $language): Response
     {
         $request = new APIRequest($this->m_auth);
         

--- a/controllers/DownloadsController.php
+++ b/controllers/DownloadsController.php
@@ -8,6 +8,9 @@
 
 namespace iRAP\VidaSDK\Controllers;
 
+use iRAP\VidaSDK\Models\Response;
+use iRAP\VidaSDK\Models\APIRequest;
+
 class DownloadsController extends AbstractResourceController
 {
     protected function getResourcePath()

--- a/controllers/DownloadsController.php
+++ b/controllers/DownloadsController.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * 
+ * Controller for the external download methods. Overrides the Abstract Resource Controller.
+ * 
+ */
+
+namespace iRAP\VidaSDK\Controllers;
+
+class DownloadsController extends AbstractResourceController
+{
+    protected function getResourcePath()
+    {
+        return 'downloads';
+    }
+    
+    
+    /**
+     * Request for a file download
+     * @param string $type could be any one of (core_before, core_before_endgps, core_after, core_after_endgps, complete_before, 
+     * complete_after, fe_before, fe_after, countermeasures, countermeasures_partial, chainages, upload)
+     * @param int $datasetId
+     * @param string $language Name of the file (not including extension)
+     * @param string $filename Language code (Defaults to en-gb)
+     * @return \iRAP\VidaSDK\Models\Response
+     */
+    public function requestDownloadFile(string $type, int $datasetId, string $filename, string $language): Response
+    {
+        $request = new APIRequest($this->m_auth);
+        
+        $data = array(
+            'filename' => $filename,
+            'language' => $language
+        );
+        
+        $url = $this->getResourcePath() . "/{$type}/{$datasetId}";
+        $request->setUrl($url);
+        $request->setPostData($data);
+        $request->send();
+        return $this->response($request);
+    }
+}


### PR DESCRIPTION
@Rockburner - I've mainly added you for information, as I don't want you to run out of things to document.

Example path:
https://api.vida.irap.org/1.0/downloads/core_before/15849

Example return:
    [status] => Success
    [code] => 200
    [response] => stdClass Object
        (
            [result] => success
            [queue_id] => 137
            [url] => https://vida.aa.irap-dev.org/resources/downloads/Otis13.zip
        )
