### PR TITLE
Enabling multiple users to be added or removed with a single request

### DIFF
--- a/controllers/AbstractApiController.php
+++ b/controllers/AbstractApiController.php
@@ -251,7 +251,7 @@ abstract class AbstractApiController implements ApiInterface
      * Grant access to the specified user for the specified dataset
      *
      * @param int $dataset_id
-     * @param int $user_id
+     * @param int|int[] $user_id
      * @param int $access_level
      * @param int $user_manager
      * @return object
@@ -267,14 +267,14 @@ abstract class AbstractApiController implements ApiInterface
      * Revokes access for the specified user for the specified dataset
      *
      * @param int $dataset_id
-     * @param int $user_id
+     * @param int ...$user_id
      * @return object
      * @throws Exception
      */
-    public function deleteDatasetUser($dataset_id, $user_id): object
+    public function deleteDatasetUser($dataset_id, ...$user_id): object
     {
         $datasetController = new DatasetsController($this->getAuth());
-        return $datasetController->deleteResource($dataset_id, array('user-access',$user_id));
+        return $datasetController->deleteResource($dataset_id, array('user-access', ...$user_id));
     }
 
     /**
@@ -463,7 +463,7 @@ abstract class AbstractApiController implements ApiInterface
      * Grant access to the specified user for the specified programme
      *
      * @param int $programme_id
-     * @param int $user_id
+     * @param int|int[] $user_id
      * @param int $access_level
      * @param int $user_manager
      * @return object
@@ -479,14 +479,14 @@ abstract class AbstractApiController implements ApiInterface
      * Revokes access for the specified user for the specified programme
      *
      * @param int $programme_id
-     * @param int $user_id
+     * @param int ...$user_id
      * @return object
      * @throws Exception
      */
-    public function deleteProgrammeUser($programme_id, $user_id): object
+    public function deleteProgrammeUser($programme_id, ...$user_id): object
     {
         $programmeController = new ProgrammesController($this->getAuth());
-        return $programmeController->deleteResource($programme_id, array('user-access',$user_id));
+        return $programmeController->deleteResource($programme_id, array('user-access', ...$user_id));
     }
 
     /**
@@ -585,7 +585,7 @@ abstract class AbstractApiController implements ApiInterface
      * Grant access to the specified user for the specified region
      *
      * @param int $region_id
-     * @param int $user_id
+     * @param int|int[] $user_id
      * @param int $access_level
      * @param int $user_manager
      * @return object
@@ -601,14 +601,14 @@ abstract class AbstractApiController implements ApiInterface
      * Revokes access for the specified user for the specified region
      *
      * @param int $region_id
-     * @param int $user_id
+     * @param int ...$user_id
      * @return object
      * @throws Exception
      */
-    public function deleteRegionUser($region_id, $user_id): object
+    public function deleteRegionUser($region_id, ...$user_id): object
     {
         $regionController = new RegionsController($this->getAuth());
-        return $regionController->deleteResource($region_id, array('user-access',$user_id));
+        return $regionController->deleteResource($region_id, array('user-access', ...$user_id));
     }
 
     /**
@@ -708,7 +708,7 @@ abstract class AbstractApiController implements ApiInterface
      * Grant access to the specified user for the specified project
      *
      * @param int $project_id
-     * @param int $user_id
+     * @param int|int[] $user_id
      * @param int $access_level
      * @param int $user_manager
      * @return object
@@ -724,14 +724,14 @@ abstract class AbstractApiController implements ApiInterface
      * Revokes access for the specified user for the specified project
      *
      * @param int $project_id
-     * @param int $user_id
+     * @param int ...$user_id
      * @return object
      * @throws Exception
      */
-    public function deleteProjectUser($project_id, $user_id): object
+    public function deleteProjectUser($project_id, ...$user_id): object
     {
         $projectController = new ProjectsController($this->getAuth());
-        return $projectController->deleteResource($project_id, array('user-access',$user_id));
+        return $projectController->deleteResource($project_id, array('user-access', ...$user_id));
     }
 
     /**

--- a/controllers/AbstractApiController.php
+++ b/controllers/AbstractApiController.php
@@ -291,8 +291,8 @@ abstract class AbstractApiController implements ApiInterface
     {
         $datasetController = new DatasetsController($this->getAuth());
         return $datasetController->putResource(
-            ['user_id' => $user_id, 'access_level' => $access_level, 'user_manager' => $user_manager],
             $dataset_id,
+            ['user_id' => $user_id, 'access_level' => $access_level, 'user_manager' => $user_manager],
             'user-access'
         );
     }
@@ -523,8 +523,8 @@ abstract class AbstractApiController implements ApiInterface
     {
         $programmeController = new ProgrammesController($this->getAuth());
         return $programmeController->putResource(
-            ['user_id' => $user_id, 'access_level' => $access_level, 'user_manager' => $user_manager],
             $programme_id,
+            ['user_id' => $user_id, 'access_level' => $access_level, 'user_manager' => $user_manager],
             'user-access'
         );
     }
@@ -665,8 +665,8 @@ abstract class AbstractApiController implements ApiInterface
     {
         $regionController = new RegionsController($this->getAuth());
         return $regionController->putResource(
-            ['user_id' => $user_id, 'access_level' => $access_level, 'user_manager' => $user_manager],
             $region_id,
+            ['user_id' => $user_id, 'access_level' => $access_level, 'user_manager' => $user_manager],
             'user-access'
         );
     }
@@ -808,8 +808,8 @@ abstract class AbstractApiController implements ApiInterface
     {
         $projectController = new ProjectsController($this->getAuth());
         return $projectController->putResource(
-            ['user_id' => $user_id, 'access_level' => $access_level, 'user_manager' => $user_manager],
             $project_id,
+            ['user_id' => $user_id, 'access_level' => $access_level, 'user_manager' => $user_manager],
             'user-access'
         );
     }

--- a/controllers/AbstractApiController.php
+++ b/controllers/AbstractApiController.php
@@ -278,6 +278,26 @@ abstract class AbstractApiController implements ApiInterface
     }
 
     /**
+     * Replace access to the specified user for the specified dataset
+     *
+     * @param int $dataset_id
+     * @param int|int[] $user_id
+     * @param int $access_level
+     * @param int $user_manager
+     * @return object
+     * @throws Exception
+     */
+    public function replaceDatasetUser($dataset_id, $user_id, int $access_level = 1, int $user_manager = 0): object
+    {
+        $datasetController = new DatasetsController($this->getAuth());
+        return $datasetController->putResource(
+            ['user_id' => $user_id, 'access_level' => $access_level, 'user_manager' => $user_manager],
+            $dataset_id,
+            'user-access'
+        );
+    }
+
+    /**
      * Get a list of datasets for a programme, using the programme's ID.
      *
      * @param int $id
@@ -490,6 +510,26 @@ abstract class AbstractApiController implements ApiInterface
     }
 
     /**
+     * Replace access to the specified user for the specified programme
+     *
+     * @param int $programme_id
+     * @param int|int[] $user_id
+     * @param int $access_level
+     * @param int $user_manager
+     * @return object
+     * @throws Exception
+     */
+    public function replaceProgrammeUser($programme_id, $user_id, int $access_level = 1, int $user_manager = 0): object
+    {
+        $programmeController = new ProgrammesController($this->getAuth());
+        return $programmeController->putResource(
+            ['user_id' => $user_id, 'access_level' => $access_level, 'user_manager' => $user_manager],
+            $programme_id,
+            'user-access'
+        );
+    }
+
+    /**
      * Fetches a list of all the regions in the system. If you specify an ID, that region will be
      * returned to you.
      *
@@ -609,6 +649,26 @@ abstract class AbstractApiController implements ApiInterface
     {
         $regionController = new RegionsController($this->getAuth());
         return $regionController->deleteResource($region_id, array('user-access', ...$user_id));
+    }
+
+    /**
+     * Replace access to the specified user for the specified region
+     *
+     * @param int $region_id
+     * @param int|int[] $user_id
+     * @param int $access_level
+     * @param int $user_manager
+     * @return object
+     * @throws Exception
+     */
+    public function replaceRegionUser($region_id, $user_id, int $access_level = 1, int $user_manager = 0): object
+    {
+        $regionController = new RegionsController($this->getAuth());
+        return $regionController->putResource(
+            ['user_id' => $user_id, 'access_level' => $access_level, 'user_manager' => $user_manager],
+            $region_id,
+            'user-access'
+        );
     }
 
     /**
@@ -732,6 +792,26 @@ abstract class AbstractApiController implements ApiInterface
     {
         $projectController = new ProjectsController($this->getAuth());
         return $projectController->deleteResource($project_id, array('user-access', ...$user_id));
+    }
+
+    /**
+     * Replace access to the specified user for the specified project
+     *
+     * @param int $project_id
+     * @param int|int[] $user_id
+     * @param int $access_level
+     * @param int $user_manager
+     * @return object
+     * @throws Exception
+     */
+    public function replaceProjectUser($project_id, $user_id, int $access_level = 1, int $user_manager = 0): object
+    {
+        $projectController = new ProjectsController($this->getAuth());
+        return $projectController->putResource(
+            ['user_id' => $user_id, 'access_level' => $access_level, 'user_manager' => $user_manager],
+            $project_id,
+            'user-access'
+        );
     }
 
     /**

--- a/controllers/ApiInterface.php
+++ b/controllers/ApiInterface.php
@@ -33,6 +33,8 @@ interface ApiInterface
 
     public function deleteDatasetUser($dataset_id, ...$user_id);
 
+    public function replaceDatasetUser($dataset_id, $user_id);
+
     public function getDatasetsForProgramme($id);
 
     public function getDatasetsForRegion($id);
@@ -61,6 +63,8 @@ interface ApiInterface
 
     public function deleteProgrammeUser($programme_id, ...$user_id);
 
+    public function replaceProgrammeUser($programme_id, $user_id);
+
     public function getRegions();
 
     public function addRegion($name, $programme_id, $manager_id);
@@ -76,6 +80,8 @@ interface ApiInterface
     public function addRegionUser($region_id, $user_id);
 
     public function deleteRegionUser($region_id, ...$user_id);
+
+    public function replaceRegionUser($region_id, $user_id);
 
     public function getRegionsForProgramme($id);
 
@@ -94,6 +100,8 @@ interface ApiInterface
     public function addProjectUser($project_id, $user_id);
 
     public function deleteProjectUser($project_id, ...$user_id);
+
+    public function replaceProjectUser($project_id, $user_id);
 
     public function getProjectsForProgramme($id);
 

--- a/controllers/ApiInterface.php
+++ b/controllers/ApiInterface.php
@@ -31,7 +31,7 @@ interface ApiInterface
 
     public function addDatasetUser($dataset_id, $user_id);
 
-    public function deleteDatasetUser($dataset_id, $user_id);
+    public function deleteDatasetUser($dataset_id, ...$user_id);
 
     public function getDatasetsForProgramme($id);
 
@@ -59,7 +59,7 @@ interface ApiInterface
 
     public function addProgrammeUser($programme_id, $user_id);
 
-    public function deleteProgrammeUser($programme_id, $user_id);
+    public function deleteProgrammeUser($programme_id, ...$user_id);
 
     public function getRegions();
 
@@ -75,7 +75,7 @@ interface ApiInterface
 
     public function addRegionUser($region_id, $user_id);
 
-    public function deleteRegionUser($region_id, $user_id);
+    public function deleteRegionUser($region_id, ...$user_id);
 
     public function getRegionsForProgramme($id);
 
@@ -93,7 +93,7 @@ interface ApiInterface
 
     public function addProjectUser($project_id, $user_id);
 
-    public function deleteProjectUser($project_id, $user_id);
+    public function deleteProjectUser($project_id, ...$user_id);
 
     public function getProjectsForProgramme($id);
 


### PR DESCRIPTION
- User access, applies to programmes, regions, projects and datasets
- Replace user access request added (This is added so the user access can easily be managed without having to delete an existing access first before updating it, as there's no update method)