### PR TITLE
PHP8.4: Updated methods to explicitly declare null types where required

### DIFF
--- a/controllers/AbstractApiController.php
+++ b/controllers/AbstractApiController.php
@@ -70,7 +70,7 @@ abstract class AbstractApiController implements ApiInterface
      * @return object
      * @throws Exception
      */
-    public function getUsers(int $id = null, $filter = null): object
+    public function getUsers(int|null $id = null, $filter = null): object
     {
         $userController = new UsersController($this->getAuth(), $filter);
         return $userController->getResource($id);
@@ -100,7 +100,7 @@ abstract class AbstractApiController implements ApiInterface
      * @return object
      * @throws Exception
      */
-    public function getDatasets(int $id = null, $filter = null): object
+    public function getDatasets(int|null $id = null, $filter = null): object
     {
         $datasetController = new DatasetsController($this->getAuth(), $filter);
         return $datasetController->getResource($id);
@@ -123,7 +123,7 @@ abstract class AbstractApiController implements ApiInterface
     public function addDataset(string $name, $project_id, $manager_id,
                                int $country_id,
                                int $type = App::DATASET_TYPE_UNKNOWN,
-                               string $assessment_date = null,
+                               string|null $assessment_date = null,
                                string $description = ''): object
     {
         $datasetController = new DatasetsController($this->getAuth());
@@ -155,7 +155,7 @@ abstract class AbstractApiController implements ApiInterface
     public function updateDataset($id, string $name, $project_id, $manager_id,
                                   int $country_id,
                                   int $type = App::DATASET_TYPE_UNKNOWN,
-                                  string $assessment_date = null,
+                                  string|null $assessment_date = null,
                                   string $description = ''): object
     {
         $datasetController = new DatasetsController($this->getAuth());
@@ -205,7 +205,7 @@ abstract class AbstractApiController implements ApiInterface
      */
     public function replaceDataset($id, string $name, $project_id, $manager_id,
                                    int $type = App::DATASET_TYPE_UNKNOWN,
-                                   string $assessment_date = null,
+                                   string|null $assessment_date = null,
                                    string $description = ''): object
     {
         $datasetController = new DatasetsController($this->getAuth());
@@ -399,7 +399,7 @@ abstract class AbstractApiController implements ApiInterface
      * @return object
      * @throws Exception
      */
-    public function getProgrammes(int $id = null, $filter = null): object
+    public function getProgrammes(int|null $id = null, $filter = null): object
     {
         $programmeController = new ProgrammesController($this->getAuth(), $filter);
         return $programmeController->getResource($id);
@@ -538,7 +538,7 @@ abstract class AbstractApiController implements ApiInterface
      * @return object
      * @throws Exception
      */
-    public function getRegions(int $id = null, $filter = null): object
+    public function getRegions(int|null $id = null, $filter = null): object
     {
         $regionController = new RegionsController($this->getAuth(), $filter);
         return $regionController->getResource($id);
@@ -694,7 +694,7 @@ abstract class AbstractApiController implements ApiInterface
      * @return object
      * @throws Exception
      */
-    public function getProjects(int $id = null, $filter = null): object
+    public function getProjects(int|null $id = null, $filter = null): object
     {
         $projectController = new ProjectsController($this->getAuth(), $filter);
         return $projectController->getResource($id);
@@ -865,7 +865,7 @@ abstract class AbstractApiController implements ApiInterface
      * @return object
      * @throws Exception
      */
-    public function getVariables(int $id = null, $filter = null): object
+    public function getVariables(int|null $id = null, $filter = null): object
     {
         $variableController = new VariablesController($this->getAuth(), $filter);
         return $variableController->getResource($id);
@@ -1914,7 +1914,7 @@ abstract class AbstractApiController implements ApiInterface
      * @return object
      * @throws Exception
      */
-    public function getCountries(int $id = null, $filter = null): object
+    public function getCountries(int|null $id = null, $filter = null): object
     {
         $countriesController = new CountriesController($this->getAuth(), $filter);
         return $countriesController->getResource($id);
@@ -2028,8 +2028,12 @@ abstract class AbstractApiController implements ApiInterface
      * accepting an invitation
      * @throws Exception
      */
-    public function inviteUser(string $email, string $first_name = null,
-                               string $last_name = null, array $permissions = []): object
+    public function inviteUser(
+        string $email,
+        string|null $first_name = null,
+        string|null $last_name = null,
+        array $permissions = []
+    ): object
     {
         $inviteCtrl = new InviteController($this->getAuth());
         return $inviteCtrl->invite($email, $first_name, $last_name, $permissions);

--- a/controllers/ApiInterface.php
+++ b/controllers/ApiInterface.php
@@ -221,7 +221,7 @@ interface ApiInterface
 
     public function addReportFilter($filter_json);
 
-    public function inviteUser(string $email, string $first_name = null, string $last_name = null, array $permissions = []);
+    public function inviteUser(string $email, string|null $first_name = null, string|null $last_name = null, array $permissions = []);
 
     public function getInviteDetails($value);
 

--- a/controllers/InviteController.php
+++ b/controllers/InviteController.php
@@ -23,9 +23,12 @@ class InviteController extends AbstractResourceController
     /**
      * @throws Exception
      */
-    public function invite(string $email, string $first_name = null,
-                           string $last_name = null,
-                           array  $permissions = []): Response
+    public function invite(
+        string $email,
+        string|null $first_name = null,
+        string|null $last_name = null,
+        array  $permissions = []
+    ): Response
     {
         $data = ['email' => $email];
 

--- a/controllers/PermissionController.php
+++ b/controllers/PermissionController.php
@@ -79,7 +79,7 @@ class PermissionController extends AbstractResourceController
     /**
      * @throws Exception
      */
-    public function hasPermission(int $userId, string $identifier = null): Response
+    public function hasPermission(int $userId, string|null $identifier = null): Response
     {
         if (self::$response->getCode() === 200) {
             $hasPermission = false;
@@ -104,7 +104,7 @@ class PermissionController extends AbstractResourceController
     /**
      * @throws Exception
      */
-    public function isManager(int $userId, string $identifier = null): Response
+    public function isManager(int $userId, string|null $identifier = null): Response
     {
         if (self::$response->getCode() === 200) {
             $isManager = false;

--- a/controllers/StarRatingsController.php
+++ b/controllers/StarRatingsController.php
@@ -43,7 +43,7 @@ class StarRatingsController extends AbstractResourceController
      * @param FilterInterface|null $filter
      * @return APIRequest
      */
-    public function getBeforeStarRatingsForDatasetRequest(int $datasetID, FilterInterface $filter = null): APIRequest
+    public function getBeforeStarRatingsForDatasetRequest(int $datasetID, FilterInterface|null $filter = null): APIRequest
     {
         $request = new APIRequest($this->m_auth);
         $args = array('dataset', $datasetID, 'before');
@@ -58,7 +58,7 @@ class StarRatingsController extends AbstractResourceController
      * @param FilterInterface|null $filter
      * @return APIRequest
      */
-    public function getAfterStarRatingsForDatasetRequest(int $datasetID, FilterInterface $filter = null): APIRequest
+    public function getAfterStarRatingsForDatasetRequest(int $datasetID, FilterInterface|null $filter = null): APIRequest
     {
         $request = new APIRequest($this->m_auth);
         $args = array('dataset', $datasetID, 'after');
@@ -72,7 +72,7 @@ class StarRatingsController extends AbstractResourceController
      * @param FilterInterface|null $filter
      * @return APIRequest
      */
-    public function getBeforeDecimalStarRatingsForDatasetRequest(int $datasetID, FilterInterface $filter = null): APIRequest
+    public function getBeforeDecimalStarRatingsForDatasetRequest(int $datasetID, FilterInterface|null $filter = null): APIRequest
     {
         $request = new APIRequest($this->m_auth);
         $args = ['for', 'dataset', $datasetID, 'before'];
@@ -86,7 +86,7 @@ class StarRatingsController extends AbstractResourceController
      * @param FilterInterface|null $filter
      * @return APIRequest
      */
-    public function getAfterDecimalStarRatingsForDatasetRequest(int $datasetID, FilterInterface $filter = null): APIRequest
+    public function getAfterDecimalStarRatingsForDatasetRequest(int $datasetID, FilterInterface|null $filter = null): APIRequest
     {
         $request = new APIRequest($this->m_auth);
         $args = ['for', 'dataset', $datasetID, 'after'];


### PR DESCRIPTION
PHP8.4 has deprecated the declaration of null types implicitly when declaring a method: eg:  `, string $param = null, ` .  
The fix is to explicitly declare the type as possibly null, eg: `, string|null $param = null,` or `, ?string $param = null,`.  

Ironically, if a type is not declared : `, $param = null,` this is not deprecated, and the null type does not appear to be required to be specifically required.